### PR TITLE
Remove unnecessary local lib dependancy

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,10 +12,9 @@
     "assets"
   ],
   "dependencies": {
-    "intro.js": "0.5.0",
-    "lib": "lib"
+    "intro.js": "0.5.0"
   },
   "devDependencies": {
-   
+
   }
 }


### PR DESCRIPTION
This line caused `bower install` not finding lib package in the bower registry...
