### PR TITLE
intro will fire the exit() method on location change

### DIFF
--- a/src/angular-intro.js
+++ b/src/angular-intro.js
@@ -121,6 +121,11 @@
                     }
                     autoStartWatch();
                 });
+
+                scope.$on('$locationChangeSuccess', function() {
+                    if (typeof intro !== 'undefined')
+                        intro.exit();
+                });
             }
         };
     }]);


### PR DESCRIPTION
After an intro has been initiated, if the user clicks the back button, and angular is the one handling the location change (meaning the is no reloading of the page) - the intro will stay opened.
This commit prevents this issue.