### PR TITLE
Checking callback type

### DIFF
--- a/src/angular-intro.js
+++ b/src/angular-intro.js
@@ -113,7 +113,8 @@
 
                 scope.ngIntroExitMethod = function (callback) {
                     intro.exit();
-                    callback();
+                    if (typeof callback === 'function')
+                        callback();
                 };
 
                 var autoStartWatch = scope.$watch('ngIntroAutostart', function () {


### PR DESCRIPTION
Checking callback parameter, allowing the use of ngIntroExitMethod without a callback function and no "callback is undefined" error