### PR TITLE
Fixing npm deployment - take 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,18 @@ sudo: false
 
 language: node_js
 node_js:
-  - "0.10"
+  - "4"
 
 notifications:
     email: false
 
+before_install:
+  - npm install -g npm@'>=3'
+
 install:
   - npm install
   - node_modules/.bin/bower install
+
 
 script:
   # Just run the default task and make sure it builds, there aren't any tests :(


### PR DESCRIPTION
The [latest release](https://github.com/mendhak/angular-intro.js/releases/tag/v3.1.3) still didn't auto-deploy.  I think this is because the node and npm versions were so old.  I've now updated the node/npm versions. 

Can you review/approve/merge